### PR TITLE
[fix for upstream bug 1231339] fixes fatal startup error with swift prox...

### DIFF
--- a/keystone/exception.py
+++ b/keystone/exception.py
@@ -16,6 +16,7 @@
 
 from keystone.common import config
 from keystone.openstack.common import log as logging
+from keystone.openstack.common.gettextutils import _
 
 
 CONF = config.CONF


### PR DESCRIPTION
...y.

This is a fix for upstream bug 1231339 we will carry until fixed upstream. It allows the swift proxy server to start without encountering a fatal error if S3 middleware is enabled.
