### PR TITLE
Gracefully handle consumer cancel notifications

### DIFF
--- a/keystone/openstack/common/rpc/impl_kombu.py
+++ b/keystone/openstack/common/rpc/impl_kombu.py
@@ -504,6 +504,7 @@ class Connection(object):
             self.connection = None
         self.connection = kombu.connection.BrokerConnection(**params)
         self.connection_errors = self.connection.connection_errors
+        self.channel_errors = self.connection.channel_errors
         if self.memory_transport:
             # Kludge to speed up tests.
             self.connection.transport.polling_interval = 0.0
@@ -575,7 +576,7 @@ class Connection(object):
         while True:
             try:
                 return method(*args, **kwargs)
-            except (self.connection_errors, socket.timeout, IOError) as e:
+            except (self.connection_errors, self.channel_errors, socket.timeout, IOError) as e:
                 if error_callback:
                     error_callback(e)
             except Exception as e:


### PR DESCRIPTION
Back ported from oslo.messaging in Icehouse.
With mirrored queues and clustered rabbit nodes a queue is still
mastered by a single rabbit node. When the rabbit node dies an
election occurs amongst the remaining nodes and a new master is
elected. When a slave is promoted to master it will close all the
open channels to its consumers but it will not close the
connections. This is reported to consumers as a consumer cancel
notification (CCN). Consumers need to re-subscribe to these queues
when they recieve a CCN.

kombu 2.1.4+ reports CCNs as channel errors. This patch updates
the ensure function to be more inline with the upstream kombu
functionality. We now monitor for channel errors as well as
connection errors and initiate a reconnect if we detect an error.

Implements: rally-user-story US6888
Upstream-Review: https://review.openstack.org/#/c/77276/
Not-in-upstream: true
