### PR TITLE
Slow down Kombu reconnect attempts

### DIFF
--- a/keystone/openstack/common/rpc/impl_kombu.py
+++ b/keystone/openstack/common/rpc/impl_kombu.py
@@ -53,6 +53,10 @@ kombu_opts = [
                default='',
                help=('SSL certification authority file '
                      '(valid only if SSL enabled)')),
+    cfg.FloatOpt('kombu_reconnect_delay',
+                default=1.0,
+                help='How long to wait before reconnecting in response to an '
+                     'AMQP consumer cancel notification.'),
     cfg.StrOpt('rabbit_host',
                default='localhost',
                help='The RabbitMQ broker address where a single node is used'),
@@ -496,6 +500,11 @@ class Connection(object):
             LOG.info(_("Reconnecting to AMQP server on "
                      "%(hostname)s:%(port)d") % params)
             try:
+                if self.conf.kombu_reconnect_delay > 0:
+                    LOG.info(_("Delaying reconnect for %1.1f seconds...") %
+                             self.conf.kombu_reconnect_delay)
+                    time.sleep(self.conf.kombu_reconnect_delay)
+
                 self.connection.release()
             except self.connection_errors:
                 pass


### PR DESCRIPTION
Back ported from oslo.messaging in Icehouse.
For a rationale for this patch, see the discussion surrounding Bug
When reconnecting to a RabbitMQ cluster with mirrored queues in
use, the attempt to release the connection can hang "indefinitely"
somewhere deep down in Kombu.  Blocking the thread for a bit
prior to release seems to kludge around the problem where it is
otherwise reproduceable.

Implements: rally-user-story US6888
Upstream-Review: https://review.openstack.org/#/c/76686/
Not-in-upstream: true
