### PR TITLE
Compare against a list not a string

### DIFF
--- a/keystone/identity/backends/hybrid-idm.py
+++ b/keystone/identity/backends/hybrid-idm.py
@@ -19,7 +19,7 @@ LDAP_USER_OBJECT_CLASS = CONF.ldap.user_objectclass
 LDAP_USER_ID_ATTRIBUTE = CONF.ldap.user_id_attribute
 LDAP_USER_TREE_DN = CONF.ldap.user_tree_dn
 LDAP_GENERIC_TREE_DN = CONF.ldap.generic_tree_dn
-LDAP_BUILTIN_USERS = CONF.ldap.builtin_users
+LDAP_BUILTIN_USERS = CONF.ldap.builtin_users.split(',')
 
 LOG = logging.getLogger(__name__)
 

--- a/keystone/identity/backends/hybrid-idm.py
+++ b/keystone/identity/backends/hybrid-idm.py
@@ -5,12 +5,15 @@ from keystone import identity
 from keystone.identity.backends import sql
 from keystone.identity.backends import ldap
 from keystone.openstack.common import log as logging
-from keystone import config
+from oslo.config import cfg
+from keystone import config as ks_cfg
 from keystone.common.ldap import core
 import uuid
 import re
 
-CONF = config.CONF
+CONF = ks_cfg.CONF
+ks_cfg.CONF.register_opt(cfg.ListOpt('builtin_users'), group='ldap')
+
 DEFAULT_DOMAIN_ID = CONF.identity.default_domain_id
 LDAP_BIND_USER = CONF.ldap.user
 LDAP_BIND_PASSWORD = CONF.ldap.password
@@ -19,7 +22,7 @@ LDAP_USER_OBJECT_CLASS = CONF.ldap.user_objectclass
 LDAP_USER_ID_ATTRIBUTE = CONF.ldap.user_id_attribute
 LDAP_USER_TREE_DN = CONF.ldap.user_tree_dn
 LDAP_GENERIC_TREE_DN = CONF.ldap.generic_tree_dn
-LDAP_BUILTIN_USERS = CONF.ldap.builtin_users.split(',')
+LDAP_BUILTIN_USERS = CONF.ldap.builtin_users
 
 LOG = logging.getLogger(__name__)
 

--- a/keystone/identity/backends/hybrid.py
+++ b/keystone/identity/backends/hybrid.py
@@ -19,7 +19,7 @@ LDAP_USER_OBJECT_CLASS = CONF.ldap.user_objectclass
 LDAP_USER_ID_ATTRIBUTE = CONF.ldap.user_id_attribute
 LDAP_USER_TREE_DN = CONF.ldap.user_tree_dn
 LDAP_GENERIC_TREE_DN = CONF.ldap.generic_tree_dn
-LDAP_BUILTIN_USERS = CONF.ldap.builtin_users
+LDAP_BUILTIN_USERS = CONF.ldap.builtin_users.split(',')
 
 LOG = logging.getLogger(__name__)
 

--- a/keystone/identity/backends/hybrid.py
+++ b/keystone/identity/backends/hybrid.py
@@ -5,12 +5,15 @@ from keystone import identity
 from keystone.identity.backends import sql
 from keystone.identity.backends import ldap
 from keystone.openstack.common import log as logging
-from keystone import config
+from oslo.config import cfg
+from keystone import config as ks_cfg
 from keystone.common.ldap import core
 import uuid
 import re
 
-CONF = config.CONF
+CONF = ks_cfg.CONF
+ks_cfg.CONF.register_opt(cfg.ListOpt('builtin_users'), group='ldap')
+
 DEFAULT_DOMAIN_ID = CONF.identity.default_domain_id
 LDAP_BIND_USER = CONF.ldap.user
 LDAP_BIND_PASSWORD = CONF.ldap.password
@@ -19,7 +22,7 @@ LDAP_USER_OBJECT_CLASS = CONF.ldap.user_objectclass
 LDAP_USER_ID_ATTRIBUTE = CONF.ldap.user_id_attribute
 LDAP_USER_TREE_DN = CONF.ldap.user_tree_dn
 LDAP_GENERIC_TREE_DN = CONF.ldap.generic_tree_dn
-LDAP_BUILTIN_USERS = CONF.ldap.builtin_users.split(',')
+LDAP_BUILTIN_USERS = CONF.ldap.builtin_users
 
 LOG = logging.getLogger(__name__)
 


### PR DESCRIPTION
The `CONF.ldap.builtin_users` is configured as a comma delimited string, and
needs to be converted to a list before comparison.

Closes-rally-bug: DE778
Not-in-upstream: true
