### PR TITLE
Moved `cfg.ListOpt` to config.py

### DIFF
--- a/keystone/common/config.py
+++ b/keystone/common/config.py
@@ -243,8 +243,7 @@ FILE_OPTIONS = {
         # (schoksey): start - New attributes added for Generic DN,user attribute suffix,built-in users list
         cfg.StrOpt('user_suffix', default=None),
         cfg.StrOpt('generic_tree_dn', default=None),
-        cfg.StrOpt('builtin_users', default=[])],
-
+        cfg.ListOpt('builtin_users', default=[])],
     'pam': [
         cfg.StrOpt('userid', default=None),
         cfg.StrOpt('password', default=None)],

--- a/keystone/identity/backends/hybrid-idm.py
+++ b/keystone/identity/backends/hybrid-idm.py
@@ -5,14 +5,12 @@ from keystone import identity
 from keystone.identity.backends import sql
 from keystone.identity.backends import ldap
 from keystone.openstack.common import log as logging
-from oslo.config import cfg
-from keystone import config as ks_cfg
+from keystone import config
 from keystone.common.ldap import core
 import uuid
 import re
 
-CONF = ks_cfg.CONF
-ks_cfg.CONF.register_opt(cfg.ListOpt('builtin_users'), group='ldap')
+CONF = config
 
 DEFAULT_DOMAIN_ID = CONF.identity.default_domain_id
 LDAP_BIND_USER = CONF.ldap.user

--- a/keystone/identity/backends/hybrid.py
+++ b/keystone/identity/backends/hybrid.py
@@ -5,14 +5,12 @@ from keystone import identity
 from keystone.identity.backends import sql
 from keystone.identity.backends import ldap
 from keystone.openstack.common import log as logging
-from oslo.config import cfg
-from keystone import config as ks_cfg
+from keystone import config
 from keystone.common.ldap import core
 import uuid
 import re
 
-CONF = ks_cfg.CONF
-ks_cfg.CONF.register_opt(cfg.ListOpt('builtin_users'), group='ldap')
+CONF = config.CONF
 
 DEFAULT_DOMAIN_ID = CONF.identity.default_domain_id
 LDAP_BIND_USER = CONF.ldap.user


### PR DESCRIPTION
Didn't realize we were setting `builtin_users` already in config.py.

Closes-rally-bug: DE1892
Not-in-upstream: true
